### PR TITLE
Support uri origin parameter

### DIFF
--- a/lib/fluent/plugin/out_mackerel.rb
+++ b/lib/fluent/plugin/out_mackerel.rb
@@ -10,6 +10,7 @@ module Fluent
     config_param :service, :string, :default => nil
     config_param :metrics_name, :string, :default => nil
     config_param :out_keys, :string
+    config_param :origin, :string, :default => nil
 
     attr_reader :mackerel
 
@@ -25,7 +26,7 @@ module Fluent
     def configure(conf)
       super
 
-      @mackerel = Mackerel::Client.new(:mackerel_api_key => conf['api_key'])
+      @mackerel = Mackerel::Client.new(:mackerel_api_key => conf['api_key'], :mackerel_origin => conf['origin'])
       @out_keys = @out_keys.split(',')
 
       if @flush_interval < 60

--- a/test/plugin/test_out_mackerel.rb
+++ b/test/plugin/test_out_mackerel.rb
@@ -37,6 +37,15 @@ class MackerelOutputTest < Test::Unit::TestCase
     flush_interval 1s
   ]
 
+  CONFIG_ORIGIN = %[
+    type mackerel
+    api_key 123456
+    hostid xyz
+    metrics_name service.${out_key}
+    out_keys val1,val2,val3
+    origin example.domain
+  ]
+
   def create_driver(conf = CONFIG, tag='test')
     Fluent::Test::BufferedOutputTestDriver.new(Fluent::MackerelOutput, tag).configure(conf)
   end
@@ -57,6 +66,9 @@ class MackerelOutputTest < Test::Unit::TestCase
 
     d = create_driver(CONFIG_SMALL_FLUSH_INTERVAL)
     assert_equal d.instance.instance_variable_get(:@flush_interval), 60
+
+    d = create_driver(CONFIG_ORIGIN)
+    assert_equal d.instance.instance_variable_get(:@origin), 'example.domain'
 
     d = create_driver()
     assert_equal d.instance.instance_variable_get(:@api_key), '123456'


### PR DESCRIPTION
This pull request is for our staging environment testing.

I need to change the default uri origin(https://mackerel.io) because our staging environment's origin is different from https://mackerel.io.

mackerel.io client in ruby has mackerel_origin parameter, so it's easy to support configuring uri origin.  
https://github.com/mackerelio/mackerel-client-ruby/blob/master/lib/mackerel/client.rb#L12
