### PR TITLE
add `use_zero_for_empty` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This plugin uses [APIv0](http://help-ja.mackerel.io/entry/spec/api/v0) of macker
   api_key 123456
   hostid xyz
   metrics_name http_status.${out_key}
+  use_zero_for_empty
   out_keys 2xx_count,3xx_count,4xx_count,5xx_count
 </match>
 ```
@@ -43,6 +44,9 @@ Then the sent metric data will look like this:
 }
 ```
 As shown above, `${out_key}` will be replaced with out_key like "2xx_count" when sending metrics.
+
+In the case some outkeys do not have value, value can be set to `0` with `use_zero_for_empty`.
+For example, you set `out_keys 2xx_count,3xx_count,4xx_count,5xx_count`, but you only get `2xx_count`, `3xx_count` and `4xx_count`, then `5xx_count` is set to `0` with `use_zero_for_emptye`.
 
 You can use `out_key_pattern` instead of `out_keys`. Input records whose key matches the pattern set to `out_key_pattern` will be sent. Either `out_keys` or `out_key_pattern` is required.
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Then the sent metric data will look like this:
 As shown above, `${out_key}` will be replaced with out_key like "2xx_count" when sending metrics.
 
 In the case some outkeys do not have value, value can be set to `0` with `use_zero_for_empty`.
-For example, you set `out_keys 2xx_count,3xx_count,4xx_count,5xx_count`, but you only get `2xx_count`, `3xx_count` and `4xx_count`, then `5xx_count` is set to `0` with `use_zero_for_emptye`.
+For example, you set `out_keys 2xx_count,3xx_count,4xx_count,5xx_count`, but you only get `2xx_count`, `3xx_count` and `4xx_count`, then `5xx_count` is set to `0` with `use_zero_for_empty`.
 
 You can use `out_key_pattern` instead of `out_keys`. Input records whose key matches the pattern set to `out_key_pattern` will be sent. Either `out_keys` or `out_key_pattern` is required.
 

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ Then the sent metric data will look like this:
 ```
 As shown above, `${out_key}` will be replaced with out_key like "2xx_count" when sending metrics.
 
-In the case some outkeys do not have value, value can be set to `0` with `use_zero_for_empty`.
-For example, you set `out_keys 2xx_count,3xx_count,4xx_count,5xx_count`, but you only get `2xx_count`, `3xx_count` and `4xx_count`, then `5xx_count` is set to `0` with `use_zero_for_empty`.
+In the case some outkeys do not have any value, the value will be set to `0` with `use_zero_for_empty`, the default of which is true.
+For example, you set `out_keys 2xx_count,3xx_count,4xx_count,5xx_count`, but you only get `2xx_count`, `3xx_count` and `4xx_count`, then `5xx_count` will be set to `0` with `use_zero_for_empty`.
 
 You can use `out_key_pattern` instead of `out_keys`. Input records whose key matches the pattern set to `out_key_pattern` will be sent. Either `out_keys` or `out_key_pattern` is required.
 

--- a/lib/fluent/plugin/out_mackerel.rb
+++ b/lib/fluent/plugin/out_mackerel.rb
@@ -153,6 +153,7 @@ module Fluent
     end
 
     def send(metrics)
+      log.debug("out_mackerel: #{metrics}")
       begin
         if @hostid
           @mackerel.post_metrics(metrics)

--- a/lib/fluent/plugin/out_mackerel.rb
+++ b/lib/fluent/plugin/out_mackerel.rb
@@ -13,7 +13,7 @@ module Fluent
     config_param :out_keys, :string, :default => nil
     config_param :out_key_pattern, :string, :default => nil
     config_param :origin, :string, :default => nil
-    config_param :use_zero_for_empty, :bool, :default => false
+    config_param :use_zero_for_empty, :bool, :default => true
 
     MAX_BUFFER_CHUNK_LIMIT = 100 * 1024
     config_set_default :buffer_chunk_limit, MAX_BUFFER_CHUNK_LIMIT


### PR DESCRIPTION
In the case some outkeys do not have value, value can be set to `0` with `use_zero_for_empty`.

For example, you set `out_keys 2xx_count,3xx_count,4xx_count,5xx_count`, but you only get `2xx_count`, `3xx_count` and `4xx_count`, then `5xx_count` is set to `0` with `use_zero_for_empty`.
