### PR TITLE
Support label feature

### DIFF
--- a/lib/fluent/plugin/out_mackerel_hostid_tag.rb
+++ b/lib/fluent/plugin/out_mackerel_hostid_tag.rb
@@ -14,6 +14,11 @@ module Fluent
       define_method("log") { $log }
     end
 
+    # Define `router` method to support v0.10.57 or earlier
+    unless method_defined?(:router)
+      define_method("router") { Fluent::Engine }
+    end
+
     def initialize
       super
     end

--- a/lib/fluent/plugin/out_mackerel_hostid_tag.rb
+++ b/lib/fluent/plugin/out_mackerel_hostid_tag.rb
@@ -49,7 +49,7 @@ module Fluent
         if @add_to == 'record'
           record[@key_name] = @hostid
         end
-        Fluent::Engine.emit(tag, time, record)
+        router.emit(tag, time, record)
       end
 
       chain.next


### PR DESCRIPTION
Fluentd v0.12 supports label feature.
This PR aims to support label feature and to keep backward compatibility fluentd 0.10.57 or earlier.