### PR TITLE
Support secret parameters

### DIFF
--- a/lib/fluent/plugin/out_mackerel.rb
+++ b/lib/fluent/plugin/out_mackerel.rb
@@ -4,7 +4,7 @@ module Fluent
   class MackerelOutput < Fluent::BufferedOutput
     Fluent::Plugin.register_output('mackerel', self)
 
-    config_param :api_key, :string
+    config_param :api_key, :string, :secret => true
     config_param :hostid, :string, :default => nil
     config_param :hostid_path, :string, :default => nil
     config_param :service, :string, :default => nil


### PR DESCRIPTION
Fluentd v0.12 supports secret parameter feature.
This feature works as below:

```log
  <match ...>
    type mackerel
    api_key xxxxxx
    hostid xyz
    metrics_name http_status.${out_key}
    use_zero_for_empty 
    out_keys 2xx_count,3xx_count,4xx_count,5xx_count
  </match>
</ROOT>
```

If you use older fluentd, `:secret => true` in config_param will be simply ignored.