### PR TITLE
Add notes to README in MackerelHostidTagOutput

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ To append the hostid to the tag, you can simply configure "add_to" as "tag" like
 ```
 If the input is `["test", 1407650400, {"val1"=>1, "val2"=>2, "val3"=>3, "val4"=>4}]`, then the output will be `["test.xyz", 1407650400, {"val1"=>1, "val2"=>2, "val3"=>3, "val4"=>4}]`
 
+Both `add_prefix` and `remove_prefix` options are availale to control rebuilding tags.
+
 ## TODO
 
 Pull requests are very welcome!!


### PR DESCRIPTION
I found `add_prefix` and `remove_prefix` are available, so update README.

https://github.com/mackerelio/fluent-plugin-mackerel/blob/master/lib/fluent/plugin/out_mackerel_hostid_tag.rb#L9-L10

Thanks nice plugin!