### PR TITLE
Migrate to v0.14 API

### DIFF
--- a/fluent-plugin-mackerel.gemspec
+++ b/fluent-plugin-mackerel.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "test-unit"
   spec.add_development_dependency "test-unit-rr"
-  spec.add_runtime_dependency "fluentd"
+  spec.add_runtime_dependency "fluentd", [">= 0.14.8", "< 2"]
 
   spec.required_ruby_version = '>= 1.9.3'
 end

--- a/lib/fluent/plugin/out_mackerel.rb
+++ b/lib/fluent/plugin/out_mackerel.rb
@@ -6,6 +6,8 @@ module Fluent::Plugin
 
     helpers :compat_parameters
 
+    DEFAULT_FLUSH_INTERVAL = 60
+
     config_param :api_key, :string, :secret => true
     config_param :hostid, :string, :default => nil
     config_param :hostid_path, :string, :default => nil
@@ -20,6 +22,10 @@ module Fluent::Plugin
     MAX_BUFFER_CHUNK_LIMIT = 100 * 1024
     config_set_default :buffer_chunk_limit, MAX_BUFFER_CHUNK_LIMIT
     config_set_default :buffer_queue_limit, 4096
+    config_section :buffer do
+      config_set_default :@type, 'memory'
+      config_set_default :flush_interval, DEFAULT_FLUSH_INTERVAL
+    end
 
     attr_reader :mackerel
 
@@ -48,9 +54,8 @@ module Fluent::Plugin
         raise Fluent::ConfigError, "Either 'out_keys' or 'out_key_pattern' must be specifed."
       end
 
-      if @flush_interval and @flush_interval < 60
-        log.info("flush_interval less than 60s is not allowed and overwritten to 60s")
-        @flush_interval = 60
+      if @buffer_config.flush_interval and @buffer_config.flush_interval < 60
+        raise Fluent::ConfigError, "flush_interval less than 60s is not allowed."
       end
 
       unless @hostid_path.nil?

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -23,6 +23,8 @@ unless ENV.has_key?('VERBOSE')
   $log = nulllogger
 end
 
+require 'test/unit/rr'
+require 'fluent/test/driver/output'
 require 'fluent/plugin/out_mackerel'
 require 'fluent/plugin/out_mackerel_hostid_tag'
 

--- a/test/plugin/test_out_mackerel.rb
+++ b/test/plugin/test_out_mackerel.rb
@@ -140,8 +140,9 @@ class MackerelOutputTest < Test::Unit::TestCase
       d = create_driver(CONFIG_INVALID_REMOVE_PREFIX)
     }
 
-    d = create_driver(CONFIG_SMALL_FLUSH_INTERVAL)
-    assert_equal d.instance.instance_variable_get(:@flush_interval), 60
+    assert_raise(Fluent::ConfigError) {
+      d = create_driver(CONFIG_SMALL_FLUSH_INTERVAL)
+    }
 
     d = create_driver(CONFIG_ORIGIN)
     assert_equal d.instance.instance_variable_get(:@origin), 'example.domain'
@@ -151,19 +152,19 @@ class MackerelOutputTest < Test::Unit::TestCase
     assert_equal d.instance.instance_variable_get(:@hostid), 'xyz'
     assert_equal d.instance.instance_variable_get(:@metrics_name), 'service.${out_key}'
     assert_equal d.instance.instance_variable_get(:@out_keys), ['val1','val2','val3']
-    assert_equal d.instance.instance_variable_get(:@flush_interval), 60
+    buffer = d.instance.instance_variable_get(:@buffer_config)
+    assert_equal buffer.flush_interval, 60
 
     d = create_driver(CONFIG_OUT_KEY_PATTERN)
     assert_match d.instance.instance_variable_get(:@out_key_pattern), "val1"
     assert_no_match d.instance.instance_variable_get(:@out_key_pattern), "foo"
 
     d = create_driver(CONFIG_BUFFER_LIMIT_DEFAULT)
-    assert_equal d.instance.instance_variable_get(:@buffer_chunk_limit), Fluent::MackerelOutput::MAX_BUFFER_CHUNK_LIMIT
+    assert_equal d.instance.instance_variable_get(:@buffer_chunk_limit), Fluent::Plugin::MackerelOutput::MAX_BUFFER_CHUNK_LIMIT
     assert_equal d.instance.instance_variable_get(:@buffer_queue_limit), 4096
 
     d = create_driver(CONFIG_BUFFER_LIMIT_IGNORE)
-    new_limit = Fluent::MackerelOutput::MAX_BUFFER_CHUNK_LIMIT/100
-    assert_equal d.instance.instance_variable_get(:@buffer_chunk_limit), new_limit
+    assert_equal d.instance.instance_variable_get(:@buffer_chunk_limit), Fluent::Plugin::MackerelOutput::MAX_BUFFER_CHUNK_LIMIT
 
 end
 


### PR DESCRIPTION
Hi, I've tried to migrate using v0.14 Output Plugin API.
This PR contains breaking changes which makes not to be able to use with Fluentd v0.12.
If accepting this change, it should decide to drop support Fluentd v0.12 and only support v0.14 or later.
