### PR TITLE
Fix tests for v0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 sudo: false
 language: ruby
 rvm:
-  - 1.9.3
-  - 2.0.0
   - 2.1
   - 2.2
   - 2.3.0

--- a/fluent-plugin-mackerel.gemspec
+++ b/fluent-plugin-mackerel.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "rr", ">= 1.0.0"
   spec.add_development_dependency "test-unit"
+  spec.add_development_dependency "test-unit-rr"
   spec.add_runtime_dependency "fluentd"
 
   spec.required_ruby_version = '>= 1.9.3'

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -8,7 +8,7 @@ rescue Bundler::BundlerError => e
   exit e.status_code
 end
 require 'test/unit'
-require 'rr'
+require 'test/unit/rr'
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))

--- a/test/plugin/test_out_mackerel.rb
+++ b/test/plugin/test_out_mackerel.rb
@@ -162,7 +162,8 @@ class MackerelOutputTest < Test::Unit::TestCase
     assert_equal d.instance.instance_variable_get(:@buffer_queue_limit), 4096
 
     d = create_driver(CONFIG_BUFFER_LIMIT_IGNORE)
-    assert_equal d.instance.instance_variable_get(:@buffer_chunk_limit), Fluent::MackerelOutput::MAX_BUFFER_CHUNK_LIMIT
+    new_limit = Fluent::MackerelOutput::MAX_BUFFER_CHUNK_LIMIT/100
+    assert_equal d.instance.instance_variable_get(:@buffer_chunk_limit), new_limit
 
 end
 

--- a/test/plugin/test_out_mackerel.rb
+++ b/test/plugin/test_out_mackerel.rb
@@ -88,7 +88,7 @@ class MackerelOutputTest < Test::Unit::TestCase
     type mackerel
     api_key 123456
     service xyz
-    out_keys val1,val2,val3
+    out_keys val1,val2
   ]
 
   CONFIG_SERVICE_REMOVE_PREFIX = %[
@@ -96,7 +96,7 @@ class MackerelOutputTest < Test::Unit::TestCase
     api_key 123456
     service xyz
     remove_prefix
-    out_keys val1,val2,val3
+    out_keys val1,val2
   ]
 
   CONFIG_INVALID_REMOVE_PREFIX = %[

--- a/test/plugin/test_out_mackerel.rb
+++ b/test/plugin/test_out_mackerel.rb
@@ -180,7 +180,7 @@ end
     ])
 
     ENV["TZ"]="Asia/Tokyo"
-    t = Time.strptime('2014-05-14 01:11:38', '%Y-%m-%d %T')
+    t = Time.strptime('2014-05-14 01:11:38', '%Y-%m-%d %T').to_i
     d.emit({'val1' => 1, 'val2' => 2, 'val3' => 3, 'val4' => 4}, t)
     d.emit({'val1' => 5, 'val2' => 6, 'val3' => 7, 'val4' => 8}, t)
     d.emit({'val1' => 9, 'val2' => 10}, t)
@@ -195,7 +195,7 @@ end
     ])
 
     ENV["TZ"]="Asia/Tokyo"
-    t = Time.strptime('2014-05-14 01:11:38', '%Y-%m-%d %T')
+    t = Time.strptime('2014-05-14 01:11:38', '%Y-%m-%d %T').to_i
     d.emit({'val1' => 1, 'val2' => 2, 'foo' => 3}, t)
     d.run()
   end
@@ -208,7 +208,7 @@ end
     ])
 
     ENV["TZ"]="Asia/Tokyo"
-    t = Time.strptime('2014-05-14 01:11:38', '%Y-%m-%d %T')
+    t = Time.strptime('2014-05-14 01:11:38', '%Y-%m-%d %T').to_i
     d.emit({'val1' => 1, 'val2' => 2}, t)
     d.run()
   end
@@ -221,7 +221,7 @@ end
     ])
 
     ENV["TZ"]="Asia/Tokyo"
-    t = Time.strptime('2014-05-14 01:11:38', '%Y-%m-%d %T')
+    t = Time.strptime('2014-05-14 01:11:38', '%Y-%m-%d %T').to_i
     d.emit({'val1' => 1, 'val2' => 2, 'foo' => 3}, t)
     d.run()
   end
@@ -234,7 +234,7 @@ end
     ])
 
     ENV["TZ"]="Asia/Tokyo"
-    t = Time.strptime('2014-05-14 01:11:38', '%Y-%m-%d %T')
+    t = Time.strptime('2014-05-14 01:11:38', '%Y-%m-%d %T').to_i
     d.emit({'val1' => 1, 'val2' => 2, 'foo' => 3}, t)
     d.run()
   end
@@ -248,7 +248,7 @@ end
     ])
 
     ENV["TZ"]="Asia/Tokyo"
-    t = Time.strptime('2014-05-14 01:11:38', '%Y-%m-%d %T')
+    t = Time.strptime('2014-05-14 01:11:38', '%Y-%m-%d %T').to_i
     d.emit({'val1' => 1, 'val2' => 2, 'foo' => 3}, t)
     d.run()
   end

--- a/test/plugin/test_out_mackerel_hostid_tag.rb
+++ b/test/plugin/test_out_mackerel_hostid_tag.rb
@@ -101,7 +101,7 @@ class MackerelHostidTagOutputTest < Test::Unit::TestCase
     emits = d.emits
     assert_equal 2, emits.length
     assert_equal 'test.xyz', emits[0][0] # tag
-    assert_equal 1407650400, emits[0][1] # time
+    assert_equal 1407650400, emits[0][1].to_i # time
     assert_equal 4, emits[0][2].length # record
     assert_equal 1, emits[0][2]["val1"] # record
     assert_equal 2, emits[0][2]["val2"] # record
@@ -109,7 +109,7 @@ class MackerelHostidTagOutputTest < Test::Unit::TestCase
     assert_equal 4, emits[0][2]["val4"] # record
 
     assert_equal 'test.xyz', emits[1][0] # tag
-    assert_equal 1407650400, emits[1][1] # time
+    assert_equal 1407650400, emits[1][1].to_i # time
     assert_equal 4, emits[1][2].length # record
     assert_equal 5, emits[1][2]["val1"] # record
     assert_equal 6, emits[1][2]["val2"] # record
@@ -131,7 +131,7 @@ class MackerelHostidTagOutputTest < Test::Unit::TestCase
     emits = d.emits
     assert_equal 2, emits.length
     assert_equal 'test', emits[0][0] # tag
-    assert_equal 1407650400, emits[0][1] # time
+    assert_equal 1407650400, emits[0][1].to_i # time
     assert_equal 5, emits[0][2].length # record length
     assert_equal 1, emits[0][2]["val1"] # record
     assert_equal 2, emits[0][2]["val2"] # record
@@ -140,7 +140,7 @@ class MackerelHostidTagOutputTest < Test::Unit::TestCase
     assert_equal "xyz", emits[0][2]["mackerel_hostid"] # record
 
     assert_equal 'test', emits[1][0] # tag
-    assert_equal 1407650400, emits[1][1] # time
+    assert_equal 1407650400, emits[1][1].to_i # time
     assert_equal 5, emits[1][2].length # record length
     assert_equal 5, emits[1][2]["val1"] # record
     assert_equal 6, emits[1][2]["val2"] # record
@@ -162,7 +162,7 @@ class MackerelHostidTagOutputTest < Test::Unit::TestCase
     emits = d.emits
     assert_equal 1, emits.length
     assert_equal 'service', emits[0][0] # tag
-    assert_equal 1407650400, emits[0][1] # time
+    assert_equal 1407650400, emits[0][1].to_i # time
     assert_equal 5, emits[0][2].length # record length
     assert_equal 1, emits[0][2]["val1"] # record
     assert_equal 2, emits[0][2]["val2"] # record
@@ -185,7 +185,7 @@ class MackerelHostidTagOutputTest < Test::Unit::TestCase
     emits = d.emits
     assert_equal 1, emits.length
     assert_equal 'mackerel.test', emits[0][0] # tag
-    assert_equal 1407650400, emits[0][1] # time
+    assert_equal 1407650400, emits[0][1].to_i # time
     assert_equal 5, emits[0][2].length # record length
     assert_equal 1, emits[0][2]["val1"] # record
     assert_equal 2, emits[0][2]["val2"] # record
@@ -208,7 +208,7 @@ class MackerelHostidTagOutputTest < Test::Unit::TestCase
     emits = d.emits
     assert_equal 1, emits.length
     assert_equal 'mackerel.service', emits[0][0] # tag
-    assert_equal 1407650400, emits[0][1] # time
+    assert_equal 1407650400, emits[0][1].to_i # time
     assert_equal 5, emits[0][2].length # record length
     assert_equal 1, emits[0][2]["val1"] # record
     assert_equal 2, emits[0][2]["val2"] # record
@@ -231,7 +231,7 @@ class MackerelHostidTagOutputTest < Test::Unit::TestCase
     emits = d.emits
     assert_equal 1, emits.length
     assert_equal 'mackerel.service.xyz', emits[0][0] # tag
-    assert_equal 1407650400, emits[0][1] # time
+    assert_equal 1407650400, emits[0][1].to_i # time
     assert_equal 4, emits[0][2].length # record length
     assert_equal 1, emits[0][2]["val1"] # record
     assert_equal 2, emits[0][2]["val2"] # record


### PR DESCRIPTION
I've noticed that tests are failing with v0.14's v0.12 compatibility layer.
If merging this, please consider before merging #18.
