### PR TITLE
Allow flush_interval less than 60s

### DIFF
--- a/lib/fluent/plugin/out_mackerel.rb
+++ b/lib/fluent/plugin/out_mackerel.rb
@@ -46,8 +46,7 @@ module Fluent
       end
 
       if @flush_interval < 60
-        log.info("flush_interval less than 60s is not allowed and overwritten to 60s")
-        @flush_interval = 60
+        log.warn("flush_interval less than 60s is not recommended")
       end
 
       unless @hostid_path.nil?

--- a/test/plugin/test_out_mackerel.rb
+++ b/test/plugin/test_out_mackerel.rb
@@ -141,7 +141,7 @@ class MackerelOutputTest < Test::Unit::TestCase
     }
 
     d = create_driver(CONFIG_SMALL_FLUSH_INTERVAL)
-    assert_equal d.instance.instance_variable_get(:@flush_interval), 60
+    assert_equal d.instance.instance_variable_get(:@flush_interval), 1
 
     d = create_driver(CONFIG_ORIGIN)
     assert_equal d.instance.instance_variable_get(:@origin), 'example.domain'


### PR DESCRIPTION
When I had very many `plugin-mackerel` configuration sections, CPU spikes occur at every `flush_interval` (= 60s in my environment) seconds.

If `flush_interval` is set 1s, each plugin flushes at random depending on input timing. 

I guess that `flush_interval` less than 60s became not allowed, because a large amount of flushing make placing loads on `mackerel servers`. But this is not always true, for example when I use [in-cloudwatch plugin](https://github.com/yunomu/fluent-plugin-cloudwatch) to fetch data every 60s. So, I think that it is better to allow any `flush_interval` and warn against `flush_interval` less than 60s.

I'm posting this PR to get more feedback on this issue.

[MEMO] This issue might somewhat be similar to https://github.com/yunomu/fluent-plugin-cloudwatch/pull/15.

```
# Use case. You can reproduce cpu spikes when putting many blocks like this below.
<source>
    id in-cloudwatch-cloudwatch_hogehoge_redis1_bytes_used_for_cache
    type cloudwatch
    tag cloudwatch.redis_bytes_used_for_cache
    aws_key_id xxxxxx
    aws_sec_key xxxxxx
    cw_endpoint monitoring.ap-northeast-1.amazonaws.com
    period 60
    interval 60
    delayed_start true
    namespace AWS/ElastiCache
    metric_name BytesUsedForCache
    dimensions_name CacheClusterId,CacheNodeId
    dimensions_value hogehoge-redis1,0001
</source>
<match cloudwatch.redis_bytes_used_for_cache>
    id out-mackerel-cloudwatch_hogehoge_redis1_bytes_used_for_cache
    type mackerel
    api_key xxxxxx
    service hogehoge
    metrics_name ${[1]}.${out_key}
    out_key_pattern .*
    flush_interval 1
</match>
```