### PR TITLE
Update dependency to use new API BaseURL

### DIFF
--- a/fluent-plugin-mackerel.gemspec
+++ b/fluent-plugin-mackerel.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "mackerel-client"
+  spec.add_dependency "mackerel-client", ">= 0.3.0"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
Ref: https://github.com/mackerelio/mackerel-agent/pull/417

fluent-plugin-mackerel uses mackerel-client-ruby internally, so I'd like to update the gem.
https://github.com/mackerelio/mackerel-client-ruby/pull/31
