### PR TITLE
fix mackerel-client gem version to 0.3.0

### DIFF
--- a/fluent-plugin-mackerel.gemspec
+++ b/fluent-plugin-mackerel.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "mackerel-client", ">= 0.3.0"
+  spec.add_dependency "mackerel-client", "0.3.0"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
## Summary

We recently executed `td-agent-gem install fluent-plugin-mackerel` as a part of our operation routine.
As a result, the version of `mackerel-agent` gem was updated from 0.3.0 to 0.4.0 and,
it seems that `fluent-plugin-mackerel` does not work with it.
So we want to fix the version of mackerel-client gem to 0.3.0 in `fluent-plugin-mackerel.gemspec`.

```
2017-11-29 18:02:30 +0900 [warn]: #0 unexpected error while calling terminate on output plugin plugin=Fluent::Plugin::MackerelOutput plugin_id="object:3f9907c478c4" error_class=NameError error="uninitialized constant Mackerel::REST::Metric::ApiCommand"
```