### PR TITLE
Change `send` method’s name

### DIFF
--- a/lib/fluent/plugin/out_mackerel.rb
+++ b/lib/fluent/plugin/out_mackerel.rb
@@ -160,11 +160,11 @@ module Fluent::Plugin
         end
       end
 
-      send(metrics) unless metrics.empty?
+      send_metrics(metrics) unless metrics.empty?
       metrics.clear
     end
 
-    def send(metrics)
+    def send_metrics(metrics)
       log.debug("out_mackerel: #{metrics}")
       begin
         if @hostid


### PR DESCRIPTION
Resolve #26 

- fluentd root agent use `Object#send` to this instance.
https://github.com/fluent/fluentd/blob/v0.14.25/lib/fluent/root_agent.rb#L205