### PR TITLE
adapt for latest mackerel client v0.4.0

### DIFF
--- a/fluent-plugin-mackerel.gemspec
+++ b/fluent-plugin-mackerel.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "mackerel-client", ">= 0.3.0"
+  spec.add_dependency "mackerel-client", "0.4.0"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"

--- a/lib/fluent/plugin/out_mackerel.rb
+++ b/lib/fluent/plugin/out_mackerel.rb
@@ -1,4 +1,4 @@
-require 'mackerel/client'
+require 'mackerel-client'
 
 module Fluent::Plugin
   class MackerelOutput < Output

--- a/lib/fluent/plugin/out_mackerel.rb
+++ b/lib/fluent/plugin/out_mackerel.rb
@@ -1,4 +1,4 @@
-require 'mackerel-client'
+require 'mackerel'
 
 module Fluent::Plugin
   class MackerelOutput < Output


### PR DESCRIPTION
## Summary


* require `mackerel-client` instead of `mackerel/client` for mackerel-client v0.4.0
* fix mackerel-client gem version to v0.4.0 in gemspec

## Note

* this p-r may be better than #25